### PR TITLE
Mms v2 can switch image and text order

### DIFF
--- a/lib/skycore/payload_builder.rb
+++ b/lib/skycore/payload_builder.rb
@@ -135,10 +135,17 @@ class Skycore
         x.CUSTOMSUBJECT(subject) if subject
         slides.each_with_index do |slide, ix|
           if slide['type'] == 'text'
+          if slide[:type] == 'text'
             x.CUSTOMTEXT {
               x.VALUE slide['content']
+              x.VALUE slide[:content]
               x.SLIDE ix + 1
             }
+          elsif slide[:type] == 'attachment'
+            x.tag!(slide[:kind].upcase) do
+              x.URL slide[:url]
+              x.SLIDE ix + 1
+            end
           end
         end
       }

--- a/lib/skycore/payload_builder.rb
+++ b/lib/skycore/payload_builder.rb
@@ -134,10 +134,8 @@ class Skycore
         x.FROM from
         x.CUSTOMSUBJECT(subject) if subject
         slides.each_with_index do |slide, ix|
-          if slide['type'] == 'text'
           if slide[:type] == 'text'
             x.CUSTOMTEXT {
-              x.VALUE slide['content']
               x.VALUE slide[:content]
               x.SLIDE ix + 1
             }

--- a/lib/skycore/payload_builder.rb
+++ b/lib/skycore/payload_builder.rb
@@ -48,6 +48,23 @@ class Skycore
       }
     end
 
+    # Builds text on image on separate slides as follows:
+    #
+    # <REQUEST>
+    #   <ACTION>saveMMS</ACTION>
+    #   <API_KEY>my_key</API_KEY> <!-- api_key -->
+    #   <NAME>tatango_test</NAME>
+    #   <FALLBACKSMSTEXT>Hello</FALLBACKSMSTEXT> <!-- fallback_text -->
+    #   <!-- / for each slide -->
+    #   <SLIDE>
+    #     <TEXT>Hello</TEXT> <!-- text -->
+    #   </SLIDE>
+    #   <SLIDE>
+    #     <IMAGE>
+    #     </IMAGE>
+    #       <URL>http://app.tatango.com/tatango_logo.png</URL>
+    #   </SLIDE>
+    # </REQUEST>
     def build_save_mms_v2(subject, fallback_text, slides)
       api_key = @api_key
 
@@ -61,11 +78,11 @@ class Skycore
         x.SUBJECT subject if subject
         slides.each do |slide|
           x.SLIDE {
-            if slide['type'] == 'text'
-              x.TEXT slide['content']
-            elsif slide['type'] == 'attachment' && !slide['url'].to_s.empty?
-              x.tag!(slide['kind'].upcase) do
-                x.URL slide['url']
+            if slide[:type] == 'text'
+              x.TEXT slide[:content]
+            elsif slide[:type] == 'attachment' && !slide[:url].to_s.empty?
+              x.tag!(slide[:kind].upcase) do
+                x.URL slide[:url]
               end
             end
           }

--- a/spec/payload_builder_spec.rb
+++ b/spec/payload_builder_spec.rb
@@ -6,13 +6,13 @@ describe Skycore::PayloadBuilder do
 
   context '#build_save_mms' do
     it "has correct api_key" do
-      payload = builder.build_save_mms("Hello", "Fallback SMS", [])
+      payload = builder.build_save_mms("", "Hello", "Fallback SMS", [])
       parsed = Crack::XML.parse(payload)
       expect(parsed["REQUEST"]["API_KEY"]).to eq(api_key)
     end
 
     it "includes fallback text" do
-      payload = builder.build_save_mms("Hello", "Fallback SMS", [])
+      payload = builder.build_save_mms("", "Hello", "Fallback SMS", [])
       parsed = Crack::XML.parse(payload)
       expect(parsed["REQUEST"]["FALLBACKSMSTEXT"]).to eq("Fallback SMS")
     end

--- a/spec/payload_builder_spec.rb
+++ b/spec/payload_builder_spec.rb
@@ -6,7 +6,7 @@ describe Skycore::PayloadBuilder do
 
   context '#build_save_mms' do
     it "has correct api_key" do
-      payload = builder.build_save_mms("Hello", "Hello", [])
+      payload = builder.build_save_mms("Hello", "Fallback SMS", [])
       parsed = Crack::XML.parse(payload)
       expect(parsed["REQUEST"]["API_KEY"]).to eq(api_key)
     end
@@ -18,16 +18,28 @@ describe Skycore::PayloadBuilder do
     end
 
     it "builds simple text" do
-      payload = builder.build_save_mms("Hello", "Hello", [])
+      payload = builder.build_save_mms("", "Hello", "Fallback SMS", [])
       parsed = Crack::XML.parse(payload)
       slide = parsed["REQUEST"]["SLIDE"]
+      subject = parsed["REQUEST"]["SUBJECT"]
       expect(slide.keys.size).to eq(1)
+      expect(subject).to eq(nil)
+      expect(slide["TEXT"]).to eq("Hello")
+    end
+
+    it "builds subject and text" do
+      payload = builder.build_save_mms("Hi", "Hello", "Fallback SMS", [])
+      parsed = Crack::XML.parse(payload)
+      slide = parsed["REQUEST"]["SLIDE"]
+      subject = parsed["REQUEST"]["SUBJECT"]
+      expect(slide.keys.size).to eq(1)
+      expect(subject).to eq("Hi")
       expect(slide["TEXT"]).to eq("Hello")
     end
 
     it "builds text + image" do
       image_url = "http://app.tatango.com/tatango_logo.png"
-      payload = builder.build_save_mms("Hello", "Hello", [
+      payload = builder.build_save_mms("", "Hello", "Fallback SMS", [
         {
           type: "IMAGE",
           url: image_url
@@ -39,6 +51,74 @@ describe Skycore::PayloadBuilder do
       expect(slide["TEXT"]).to eq("Hello")
       expect(slide["IMAGE"]["URL"]).to eq(image_url)
     end
+  end
+
+  context '#build_save_mms_v2' do
+    # Accepts (subject, fallbacktext, slide) as argument
+    # `slide` looks for the `type`, `content`, `kind`, and/or `url` parameters
+    #  `type` should be `text` or `attachment` and `kind` should be `image`
+    image_url = "http://app.tatango.com/tatango_logo.png"
+
+    it "has correct api_key" do
+      payload = builder.build_save_mms_v2("", "Hello", [])
+      parsed = Crack::XML.parse(payload)
+      expect(parsed["REQUEST"]["API_KEY"]).to eq(api_key)
+    end
+
+    it "builds two slides" do
+      payload = builder.build_save_mms_v2("", "Fallback SMS", [
+        {
+          type: "attachment",
+          kind: "IMAGE",
+          url: image_url
+        },
+        {
+          type: "text",
+          content: "Hello"
+        }
+      ])
+      parsed = Crack::XML.parse(payload)
+      slides = parsed["REQUEST"]["SLIDE"]
+      expect(slides.size).to eq(2)
+    end
+
+    it "builds the image slide before the text slide" do
+
+      payload = builder.build_save_mms_v2("", "Fallback SMS", [
+        {
+          type: "attachment",
+          kind: "IMAGE",
+          url: image_url
+        },
+        {
+          type: "text",
+          content: "Hello"
+        }
+      ])
+      parsed = Crack::XML.parse(payload)
+      slides = parsed["REQUEST"]["SLIDE"]
+      expect(slides[0]["IMAGE"]["URL"]).to eq(image_url)
+      expect(slides[1]["TEXT"]).to eq("Hello")
+    end
+
+    it "builds the image slide after the text slide" do
+      payload = builder.build_save_mms_v2("", "Fallback SMS", [
+        {
+          type: "text",
+          content: "Hello"
+        },
+        {
+          type: "attachment",
+          kind: "IMAGE",
+          url: image_url
+        }
+      ])
+      parsed = Crack::XML.parse(payload)
+      slides = parsed["REQUEST"]["SLIDE"]
+      expect(slides[1]["IMAGE"]["URL"]).to eq(image_url)
+      expect(slides[0]["TEXT"]).to eq("Hello")
+    end
+
   end
 
   context "#build_send_saved_mms" do

--- a/spec/payload_builder_spec.rb
+++ b/spec/payload_builder_spec.rb
@@ -148,9 +148,41 @@ describe Skycore::PayloadBuilder do
     it "builds correct OPERATORID field" do
       expect(parsed["REQUEST"]["OPERATORID"]).to eq("4")
     end
+  end
 
-    it "builds correct CAMPAIGNREF field" do
-      expect(parsed["REQUEST"]["CAMPAIGNREF"]).to eq("1337")
+  context "#build_send_saved_mms_v2" do
+    image_url = "http://app.tatango.com/tatango_logo.png"
+    let (:from) { "51044" }
+    let (:to) { "12062746598" }
+    let (:parsed) { 
+      payload = builder.build_send_saved_mms_v2(from, to, 123, "Fallback SMS", 4, 1337, [
+        {
+          type: "text",
+          content: "Hello"
+        },
+        {
+          type: "attachment",
+          kind: "IMAGE",
+          url: image_url
+        }
+      ])
+      Crack::XML.parse(payload)
+    }
+
+    it "builds correct api key" do
+      expect(parsed["REQUEST"]["API_KEY"]).to eq(api_key)
+    end
+
+    it "builds the correct FALLBACKSMSTEXT field" do
+      expect(parsed["REQUEST"]["FALLBACKSMSTEXT"]).to eq("Fallback SMS")
+    end
+
+    it "contains text content" do
+      expect(parsed["REQUEST"]["CUSTOMTEXT"]["VALUE"]).to eq("Hello")
+    end
+
+    it "contains image content" do
+      expect(parsed["REQUEST"]["IMAGE"]["URL"]).to eq(image_url)
     end
   end
 end


### PR DESCRIPTION
This PR updates the specs and improves the payload_builder, so we can add in functionality to change the order in which text and attachments appear in messages.